### PR TITLE
Fix point tallies for multi-model Tyranid units

### DIFF
--- a/Tyranids.manifest
+++ b/Tyranids.manifest
@@ -1,6 +1,6 @@
 {
   "name": "Tyranids",
-  "revision": "10.2.4",
+  "revision": "10.2.5",
   "game": "Warhammer 40k",
   "genre": "sci-fi",
   "publisher": "Games Workshop",

--- a/Tyranids.manifest
+++ b/Tyranids.manifest
@@ -3535,7 +3535,7 @@
           ]
         }
       },
-      "Model§Gargoyles": {
+      "Model§Gargoyle": {
         "stats": {
           "M": {
             "value": 12
@@ -6104,13 +6104,13 @@
             "value": 1
           },
           "model2ndCost": {
-            "value": 80
+            "value": 40
           },
           "model2ndTally": {
             "value": 2
           },
           "model3rdCost": {
-            "value": 120
+            "value": 40
           }
         }
       },
@@ -6166,7 +6166,7 @@
             "value": 1
           },
           "model2ndCost": {
-            "value": 250
+            "value": 125
           },
           "model2ndTally": {
             "value": 2
@@ -6247,7 +6247,7 @@
           ],
           "included": [
             {
-              "item": "Model§Gargoyles",
+              "item": "Model§Gargoyle",
               "quantity": 10
             }
           ]
@@ -6270,7 +6270,7 @@
         },
         "allowed": {
           "items": [
-            "Model§Gargoyles"
+            "Model§Gargoyle"
           ]
         },
         "stats": {
@@ -6289,7 +6289,7 @@
             "value": 10
           },
           "model2ndCost": {
-            "value": 150
+            "value": 75
           },
           "model2ndTally": {
             "value": 20
@@ -6359,7 +6359,7 @@
             "value": 5
           },
           "model2ndCost": {
-            "value": 180
+            "value": 90
           },
           "model2ndTally": {
             "value": 10
@@ -6646,7 +6646,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 200
+            "value": 100
           },
           "model2ndTally": {
             "value": 6
@@ -6702,7 +6702,7 @@
             "value": 10
           },
           "model2ndCost": {
-            "value": 140
+            "value": 70
           },
           "model2ndTally": {
             "value": 20
@@ -6951,7 +6951,7 @@
             "value": 1
           },
           "model2ndCost": {
-            "value": 90
+            "value": 45
           },
           "model2ndTally": {
             "value": 2
@@ -7016,7 +7016,7 @@
             "value": 11
           },
           "model2ndCost": {
-            "value": 90
+            "value": 45
           },
           "model2ndTally": {
             "value": 22
@@ -7175,13 +7175,13 @@
             "value": 1
           },
           "model2ndCost": {
-            "value": 60
+            "value": 30
           },
           "model2ndTally": {
             "value": 2
           },
           "model3rdCost": {
-            "value": 90
+            "value": 30
           }
         }
       },
@@ -7233,7 +7233,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 150
+            "value": 75
           },
           "model2ndTally": {
             "value": 6
@@ -7303,7 +7303,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 70
+            "value": 35
           },
           "model2ndTally": {
             "value": 6
@@ -7465,7 +7465,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 100
+            "value": 50
           },
           "model2ndTally": {
             "value": 6
@@ -7601,7 +7601,7 @@
             "value": 10
           },
           "model2ndCost": {
-            "value": 120
+            "value": 60
           },
           "model2ndTally": {
             "value": 20
@@ -7828,7 +7828,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 180
+            "value": 90
           },
           "model2ndTally": {
             "value": 6
@@ -7884,7 +7884,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 140
+            "value": 70
           },
           "model2ndTally": {
             "value": 6
@@ -8197,7 +8197,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 190
+            "value": 95
           },
           "model2ndTally": {
             "value": 6
@@ -8253,7 +8253,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 140
+            "value": 70
           },
           "model2ndTally": {
             "value": 6
@@ -8318,7 +8318,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 150
+            "value": 75
           },
           "model2ndTally": {
             "value": 6
@@ -8386,7 +8386,7 @@
             "value": 3
           },
           "model2ndCost": {
-            "value": 180
+            "value": 90
           },
           "model2ndTally": {
             "value": 6


### PR DESCRIPTION
This PR:
- fixes the name of the `Gargoyle` model (instead of `Gargoyles`)
- fixes the `model2ndCost` and `model3rdCost` of multi-model units where necessary 