### PR TITLE
Adeptus Mechanicus: Make Kataphron Breachers melee weapons swichable.

### DIFF
--- a/Adeptus_Mechanicus.manifest
+++ b/Adeptus_Mechanicus.manifest
@@ -2621,6 +2621,7 @@
             "value": 5
           },
           "Melee Options": {
+            "dynamic": true,
             "group": "Loadout",
             "groupOrder": 2,
             "ranks": {


### PR DESCRIPTION
Both breachers melee weapons where registered but they were not swichable:

## Before
![image](https://github.com/RosterizerTestData/Warhammer40k10e/assets/11573588/088fb9e5-e449-4da6-8fb8-085c6392a76a)

## On test manifest
![image](https://github.com/RosterizerTestData/Warhammer40k10e/assets/11573588/6c5bb116-8f57-4702-8834-b55d7c6037c6)
