### PR TITLE
Remove 2 unit limit for WE Chaos Spawn

### DIFF
--- a/World_Eaters.manifest
+++ b/World_Eaters.manifest
@@ -6126,9 +6126,6 @@
             "value": 0,
             "visibility": "hidden"
           },
-          "maxQty": {
-            "value": 2
-          },
           "model1stTally": {
             "value": 1
           },


### PR DESCRIPTION
Unless I'm missing some special rule, this limit looks like it was put in place on accident. The standard limit of 3 non-battleline units should be inherited here.