### PR TITLE
Fixed Zephyrim Superior melee weapon

### DIFF
--- a/Adepta_Sororitas.manifest
+++ b/Adepta_Sororitas.manifest
@@ -5799,6 +5799,11 @@
         }
       },
       "Model§Zephyrim Superior": {
+		    "assets": {
+          "traits": [
+            "Melee Weapon§Zephyrim Squad—Power weapon"
+          ]
+        },
         "stats": {
           "Ld": {
             "value": 7

--- a/Adepta_Sororitas.manifest
+++ b/Adepta_Sororitas.manifest
@@ -5799,7 +5799,7 @@
         }
       },
       "Model§Zephyrim Superior": {
-		    "assets": {
+        "assets": {
           "traits": [
             "Melee Weapon§Zephyrim Squad—Power weapon"
           ]


### PR DESCRIPTION
Zephyrim Superior now has correct power weapon instead of no melee weapon.